### PR TITLE
Add the badge to indicate yearly download count.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Kintone Utility for JavaScript
 [![npm version](https://badge.fury.io/js/%40shuuji3%2Fkintone-utility.svg)](https://badge.fury.io/js/%40shuuji3%2Fkintone-utility)
+[![npm download count](https://img.shields.io/npm/dy/@shuuji3/kintone-utility.svg)](https://www.npmjs.com/package/@shuuji3/kintone-utility)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/562912d851d2491d9e85e35d2a0ddb30)](https://app.codacy.com/app/shuuji3/kintone-utility?utm_source=github.com&utm_medium=referral&utm_content=shuuji3/kintone-utility&utm_campaign=Badge_Grade_Settings)
 


### PR DESCRIPTION
Adding the download count badge could make clear how this package is used.